### PR TITLE
Update for breaking changes in svelte-check 3.0

### DIFF
--- a/src/additional-svelte-jsx.d.ts
+++ b/src/additional-svelte-jsx.d.ts
@@ -22,11 +22,11 @@ type LifecycleEventDetails = {
   observer: IntersectionObserver;
 };
 
-declare namespace svelte.JSX {
-  interface HTMLProps<T> {
-    onchange?: (event: CustomEvent<ObserverEventDetails>) => void;
-    onenter?: (event: CustomEvent<ObserverEventDetails>) => void;
-    onleave?: (event: CustomEvent<ObserverEventDetails>) => void;
-    oninit?: (event: CustomEvent<LifecycleEventDetails>) => void;
+declare namespace svelteHTML {
+  interface HTMLAttributes<T> {
+    'on:change'?: (event: CustomEvent<ObserverEventDetails>) => void;
+    'on:enter'?: (event: CustomEvent<ObserverEventDetails>) => void;
+    'on:leave'?: (event: CustomEvent<ObserverEventDetails>) => void;
+    'on:init'?: (event: CustomEvent<LifecycleEventDetails>) => void;
   }
 }


### PR DESCRIPTION
Hi there,

I've been using `svelte-inview` in my own project and noticed that type checking with svelte-check in HTML templates did not work anymore since I updated to svelte-check 3. The VS Code extension is also affected since it's been using svelte-check 3 from version 106 onwards. It turns out that a [few adjustments](https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-getting-deprecation-warnings-for-sveltejsx--i-want-to-migrate-to-the-new-typings) have to be made to get it working again as svelte-check has changed its interface to get typings.

I have also changed the interface name from `HTMLProps<T>` to `HTMLAttributes<T>` as shown in the link above. In my test svelte-check did not infer the correct type when using HTMLProps, but it works with HTMLAttributes.

Let me know if you have any questions and thanks for creating this package!

