### PR TITLE
JSH: Updating peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-inview",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A Svelte action that monitors an element enters or leaves the viewport or a parent element. Performant and efficient thanks to using Intersection Observer under the hood.",
   "homepage": "https://github.com/maciekgrzybek/svelte-inview",
   "bugs": "https://github.com/maciekgrzybek/svelte-inview/issues",
@@ -95,6 +95,6 @@
     }
   },
   "peerDependencies": {
-    "svelte": "^3.0.0 || ^4.0.0"
+    "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^5.0.0-next"
   }
 }


### PR DESCRIPTION
Modifying peer dependencies to include both ^5.0.0 and ^5.0.0-next to stop NPM from throwing erroneous warnings/errors