### PR TITLE
fix: add repository metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,9 @@
   },
   "peerDependencies": {
     "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^5.0.0-next"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/maciekgrzybek/svelte-inview.git"
   }
 }


### PR DESCRIPTION
## Summary
The npm package `svelte-inview@4.0.4` is missing the `repository` field in its `package.json` metadata, while `homepage`, `bugs`, and `license` are already present.

## Fix
Added the missing `repository` field:
```json
"repository": {
  "type": "git",
  "url": "https://github.com/maciekgrzybek/svelte-inview.git"
}
```

## Verification
- `npm view svelte-inview repository` returns nothing → confirms the field is absent in published metadata
- Source `package.json` on default branch also lacks `repository`
- No dependencies, runtime code, or tests affected